### PR TITLE
Layout fix - overflow scroll

### DIFF
--- a/packages/react-drylus/src/layout/Layout.jsx
+++ b/packages/react-drylus/src/layout/Layout.jsx
@@ -61,7 +61,6 @@ const styles = {
     }
   `,
   bar: css`
-    overflow: scroll;
     display: flex;
     flex-direction: column;
   `,
@@ -93,12 +92,13 @@ const Layout = ({
   position,
   bar,
   fixed,
+  barScrollable,
 }) => {
   return (
     <div data-element="layout" className={cx(styles.layout, {
       [styles[getEnumAsClass(position)]]: position,
     })}>
-      <div className={styles.bar} data-element="layout-bar">{bar}</div>
+      <div className={cx(styles.bar, { [styles.scrollable]: barScrollable })} data-element="layout-bar">{bar}</div>
       <div className={cx(styles.content, { [styles.scrollable]: fixed })} data-element="layout-content">{children}</div>
     </div>
   );
@@ -122,6 +122,9 @@ Layout.propTypes = {
 
   /** If true the component will be fixed in place, and the children will scroll independently */
   fixed: PropTypes.bool,
+
+  /** If true the sidebar container is made scrollable */
+  barScrollable: PropTypes.bool,
 };
 
 

--- a/packages/styleguide/app/app.js
+++ b/packages/styleguide/app/app.js
@@ -25,9 +25,9 @@ const App = () => {
       <ThemeProvider>
         <Page>
           <Layout
-            // bar={<Navbar />}
             bar={<Sidebar routes={pages} />}
             position={LayoutPositions.LEFT}
+            barScrollable
             fixed>
             <Content fullHeight>
               <RoutesRenderer routes={pages} />

--- a/packages/styleguide/app/pages/layout/layout.mdx
+++ b/packages/styleguide/app/pages/layout/layout.mdx
@@ -1,6 +1,6 @@
 import { Layout, LayoutPositions } from '@drawbotics/react-drylus';
 
-import Playground from '~/components/Playground';
+import Playground, { PropsTable } from '~/components/Playground';
 
 
 export const Sidebar = ({ width }) => {
@@ -23,6 +23,8 @@ export const BottomBar = () => {
 
 
 # Layout component
+<PropsTable component={Layout} />
+
 Example with fixed navbar and standard bottom bar
 
 <Playground>


### PR DESCRIPTION
Fixes the box shadow issue for components in the `bar` prop. `overflow: scroll` is now optional through a prop