### PR TITLE
implement new splashcreen api with tests

### DIFF
--- a/packages/react-drylus/src/base/DrylusProvider.jsx
+++ b/packages/react-drylus/src/base/DrylusProvider.jsx
@@ -2,16 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ThemeProvider from './ThemeProvider';
-import { AlertsProvider, SplashScreenProvider } from '../components';
+import { AlertsProvider } from '../components';
 
 
 const DrylusProvider = ({ children, style }) => {
   return (
     <ThemeProvider style={style}>
       <AlertsProvider>
-        <SplashScreenProvider>
-          {children}
-        </SplashScreenProvider>
+        {children}
       </AlertsProvider>
     </ThemeProvider>
   );

--- a/packages/react-drylus/src/components/SplashScreen.jsx
+++ b/packages/react-drylus/src/components/SplashScreen.jsx
@@ -59,27 +59,11 @@ const styles = {
 };
 
 
-const Context = React.createContext();
-
-
-const SplashScreenProvider = ({ children }) => {
+const SplashScreen = ({
+  text,
+  visible,
+}) => {
   const [ outletElement, setOutletElement ] = useState(null);
-  const [ visible, setVisibility ] = useState(false);
-  const [ state, setState ] = useState({});
-
-  const { text } = state;
-
-  const hideSplashScreen = () => {
-    setVisibility(false);
-    setTimeout(() => setState({}), 500);
-  };
-
-  const showSplashScreen = (options) => {
-    setVisibility(true);
-    setState(options);
-  };
-
-  const updateSplashScreen = (options) => setState({ ...state, ...options });
 
   const handleEnter = () => {
     const timeline = anime.timeline({
@@ -128,61 +112,58 @@ const SplashScreenProvider = ({ children }) => {
 
   if (! outletElement) return null;
 
-  return (
-    <Context.Provider value={{ showSplashScreen, hideSplashScreen, updateSplashScreen }}>
-      {children}
-      {ReactDOM.createPortal(
-        <div className={themeStyles.root}>
-          <CSSTransition
-            timeout={300}
-            in={visible}
-            mountOnEnter
-            unmountOnExit
-            onEnter={handleEnter}
-            classNames={{
-              enter: styles.splashEnter,
-              enterActive: styles.splashEnterActive,
-              exit: styles.splashExit,
-              exitActive: styles.splashExitActive,
-            }}>
-            <div className={styles.root}>
-              <div className={styles.animation}>
-                <svg height="100%" width="100%" viewBox="0 0 300 300">
-                  <defs>
-                    <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%" gradientUnits="userSpaceOnUse">
-                      <stop offset="0%" style={{ stopColor: sv.brand, stopOpacity: 1 }} />
-                      <stop offset="100%" style={{ stopColor: sv.brandDark, stopOpacity: 1 }} />
-                    </linearGradient>
-                  </defs>
-                  <polygon className="first" id="1" stroke="url('#gradient')" fill="none" points="5,228 195,5 295,280" />
-                  <polyline className="second" id="2" stroke="url('#gradient')" fill="none" points="5,228 132,188 295,280" />
-                  <polyline className="third" id="3" stroke="url('#gradient')" fill="none" points="132,188 195,5" />
-                </svg>
+  return ReactDOM.createPortal(
+    <div className={themeStyles.root}>
+      <CSSTransition
+        timeout={300}
+        in={visible}
+        mountOnEnter
+        unmountOnExit
+        onEnter={handleEnter}
+        classNames={{
+          enter: styles.splashEnter,
+          enterActive: styles.splashEnterActive,
+          exit: styles.splashExit,
+          exitActive: styles.splashExitActive,
+        }}>
+        <div className={styles.root}>
+          <div className={styles.animation}>
+            <svg height="100%" width="100%" viewBox="0 0 300 300">
+              <defs>
+                <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%" gradientUnits="userSpaceOnUse">
+                  <stop offset="0%" style={{ stopColor: sv.brand, stopOpacity: 1 }} />
+                  <stop offset="100%" style={{ stopColor: sv.brandDark, stopOpacity: 1 }} />
+                </linearGradient>
+              </defs>
+              <polygon className="first" id="1" stroke="url('#gradient')" fill="none" points="5,228 195,5 295,280" />
+              <polyline className="second" id="2" stroke="url('#gradient')" fill="none" points="5,228 132,188 295,280" />
+              <polyline className="third" id="3" stroke="url('#gradient')" fill="none" points="132,188 195,5" />
+            </svg>
+          </div>
+          {do {
+            if (text != null) {
+              <div className={styles.text}>
+                {text}
               </div>
-              {do {
-                if (text) {
-                  <div className={styles.text}>
-                    {text}
-                  </div>
-                }
-              }}
-            </div>
-          </CSSTransition>
-        </div>,
-        document.getElementById('splash-outlet'),
-      )}
-    </Context.Provider>
+            }
+          }}
+        </div>
+      </CSSTransition>
+    </div>,
+    document.getElementById('splash-outlet'),
   );
+  // eslint-disable-next-line no-unreachable
+  return <div></div>;  // NOTE: proptypes fail if no "concrete" element is returned
 };
 
-SplashScreenProvider.propTypes = {
-  children: PropTypes.node.isRequired,
+
+SplashScreen.propTypes = {
+  /** Determines if the splash screen is visible or not */
+  visible: PropTypes.bool.isRequired,
+
+  /** Displayed under the animated logo */
+  text: PropTypes.string,
 };
 
 
-export default SplashScreenProvider;
-
-
-export function useSplashScreen() {
-  return React.useContext(Context);
-}
+export default SplashScreen;

--- a/packages/react-drylus/src/components/__tests__/Collapsible.test.js
+++ b/packages/react-drylus/src/components/__tests__/Collapsible.test.js
@@ -20,6 +20,7 @@ describe('Collapsible', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+  
   describe('opens when clicked', () => {
     let open = false;
 

--- a/packages/react-drylus/src/components/__tests__/SplashScreen.test.js
+++ b/packages/react-drylus/src/components/__tests__/SplashScreen.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { create } from 'react-test-renderer';
+
+import SplashScreen from '../SplashScreen';
+
+
+describe('SplashScreen', () => {
+  beforeAll(() => {
+    ReactDOM.createPortal = jest.fn((element, node) => {
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    ReactDOM.createPortal.mockClear();
+  });
+
+  describe('matches snapshot when', () => {
+    it('is visible without text', () => {
+      const tree = create(
+        <SplashScreen visible={true} />
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('is visible with some text', () => {
+      const tree = create(
+        <SplashScreen visible={true} text="Loading..." />
+      ).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  it('does not appear in the dom when not visible', () => {
+    const tree = create(
+      <SplashScreen visible={false} />
+    ).toJSON();
+    expect(tree).toBe(null);
+  });
+});

--- a/packages/react-drylus/src/components/__tests__/__snapshots__/SplashScreen.test.js.snap
+++ b/packages/react-drylus/src/components/__tests__/__snapshots__/SplashScreen.test.js.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplashScreen matches snapshot when is visible with some text 1`] = `
+.css-xbdtd3-ThemeProvider__root * {
+  font-family: "Rubik",sans-serif;
+}
+
+.css-xbdtd3-ThemeProvider__root a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+}
+
+.css-xbdtd3-ThemeProvider__root b,
+.css-xbdtd3-ThemeProvider__root strong {
+  font-weight: 500;
+}
+
+.css-6s53rl-SplashScreen__root {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 999999;
+  background: #212121;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.css-2xobb-SplashScreen__animation {
+  width: 130px;
+  height: 130px;
+  position: relative;
+}
+
+.css-2xobb-SplashScreen__animation > svg {
+  stroke-width: 7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke: black;
+}
+
+.css-tevnk8-SplashScreen__text {
+  margin-top: 32px;
+  color: rgba(135,155,166,0.7);
+}
+
+<div
+  className="css-xbdtd3-ThemeProvider__root"
+>
+  <div
+    className="css-6s53rl-SplashScreen__root"
+  >
+    <div
+      className="css-2xobb-SplashScreen__animation"
+    >
+      <svg
+        height="100%"
+        viewBox="0 0 300 300"
+        width="100%"
+      >
+        <defs>
+          <linearGradient
+            gradientUnits="userSpaceOnUse"
+            id="gradient"
+            x1="0%"
+            x2="0%"
+            y1="0%"
+            y2="100%"
+          >
+            <stop
+              offset="0%"
+              style={
+                Object {
+                  "stopColor": "#3DB5D0",
+                  "stopOpacity": 1,
+                }
+              }
+            />
+            <stop
+              offset="100%"
+              style={
+                Object {
+                  "stopColor": "#247488",
+                  "stopOpacity": 1,
+                }
+              }
+            />
+          </linearGradient>
+        </defs>
+        <polygon
+          className="first"
+          fill="none"
+          id="1"
+          points="5,228 195,5 295,280"
+          stroke="url('#gradient')"
+        />
+        <polyline
+          className="second"
+          fill="none"
+          id="2"
+          points="5,228 132,188 295,280"
+          stroke="url('#gradient')"
+        />
+        <polyline
+          className="third"
+          fill="none"
+          id="3"
+          points="132,188 195,5"
+          stroke="url('#gradient')"
+        />
+      </svg>
+    </div>
+    <div
+      className="css-tevnk8-SplashScreen__text"
+    >
+      Loading...
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SplashScreen matches snapshot when is visible without text 1`] = `null`;

--- a/packages/react-drylus/src/components/index.js
+++ b/packages/react-drylus/src/components/index.js
@@ -32,7 +32,7 @@ export Banner from './Banner';
 export Callout from './Callout';
 export ButtonLink from './ButtonLink';
 export AlertsProvider, { Alert, useAlert } from './AlertsProvider';
-export SplashScreenProvider, { useSplashScreen } from './SplashScreenProvider';
+export SplashScreen from './SplashScreen';
 export Breadcrumbs from './Breadcrumbs';
 export Dropdown, { DropdownSides, DropdownOption, DropdownTitle, DropdownSeparator } from './Dropdown';
 export List, { ListItem } from './List';

--- a/packages/styleguide/app/pages/component-kit/base/providers.mdx
+++ b/packages/styleguide/app/pages/component-kit/base/providers.mdx
@@ -2,7 +2,6 @@ import {
   DrylusProvider,
   ThemeProvider,
   AlertsProvider,
-  SplashScreenProvider,
 } from '@drawbotics/react-drylus';
 
 import Playground, { PropsTable } from '~/components/Playground';
@@ -40,12 +39,3 @@ import { AlertsProvider } from '@drawbotics/react-drylus';
 ```
 
 <PropsTable component={AlertsProvider} />
-
-### SplashScreenProvider
-See [`SplashScreen`](/components/splash-screen).
-
-```jsx
-import { SplashScreenProvider } from '@drawbotics/react-drylus';
-```
-
-<PropsTable component={SplashScreenProvider} />

--- a/packages/styleguide/app/pages/component-kit/components/splash-screen.mdx
+++ b/packages/styleguide/app/pages/component-kit/components/splash-screen.mdx
@@ -1,32 +1,14 @@
 import { useEffect, useState } from 'react';
-import { SplashScreenProvider, useSplashScreen } from '@drawbotics/react-drylus';
+import { SplashScreen } from '@drawbotics/react-drylus';
 
 import { PropsTable } from '~/components/Playground';
 
 
-# Splash Screen Provider
-Set this provider at the root of the project if you want to show/hide a splash screen at will. See [`Alerts`](/components/alerts) for usage, since it's essentially the same.
+# Splash Screen
+This component will take over the entirety of the user screen, and display an animated loader.
 
 Shown when a whole page should be loading and the user shouldn't perform any action. For example when the website is loading, or when an order is being placed.
-```jsx
-import { useSplashScreen } from '@drawbotics/react-drylus';
-```
-
-In your component, use the `useSplashScreen` hook like so:
-```jsx
-const { showSplashScreen, hideSplashScreen, updateSplashScreen } = useSplashScreen();
-```
-
-The functions available for interacting with the splash screen are these:
-```
-showSplashScreen(options)   // to trigger the visibility of the splash screen
-hideHideSplashScreen()          // to hide the splash screen (resets options)
-updateSplashScreen(options) // to update the options without changing the visibility
-```
-You may pass a `options` object to the `show` and `update` calls to display something during the loading step. `options` accepts the following fields:
-```
-text  // displayed below the loading animation
-```
+<PropsTable component={SplashScreen} />
 
 
 ### Demo
@@ -34,11 +16,9 @@ Press `s` on your keyboard to start the splash screen. Press it again to hide it
 
 export const Demo = () => {
   const [ visible, toggle ] = useState(false);
-  const { showSplashScreen, hideSplashScreen } = useSplashScreen();
   useEffect(() => {
     const handlePressKey = (e) => {
       if (e.code === 'KeyS') {
-        visible ? hideSplashScreen() : showSplashScreen({ text: 'Loading...' });
         toggle(! visible);
       }
     };
@@ -47,9 +27,9 @@ export const Demo = () => {
       window.removeEventListener('keydown', handlePressKey);
     };
   });
-  return '';
+  return (
+    <SplashScreen text="Loading..." visible={visible} />
+  );
 };
 
-<SplashScreenProvider>
-  <Demo />
-</SplashScreenProvider>
+<Demo />


### PR DESCRIPTION
Instead of using a provider, treat `SplashScreen` like a modal, where the visibility is directly affected by the `visibility` prop