### PR TITLE
Improve tags distinction with different text colors

### DIFF
--- a/packages/react-drylus/src/components/Tag.jsx
+++ b/packages/react-drylus/src/components/Tag.jsx
@@ -31,18 +31,23 @@ const styles = {
   `,
   brand: css`
     background: ${sv.brandLight};
+    color: ${sv.brandDark};
   `,
   danger: css`
     background: ${sv.redLight};
+    color: ${sv.redDark};
   `,
   success: css`
     background: ${sv.greenLight};
+    color: ${sv.greenDark};
   `,
   warning: css`
     background: ${sv.orangeLight};
+    color: ${sv.orangeDark};
   `,
   info: css`
     background: ${sv.blueLight};
+    color: ${sv.blueDark};
   `,
   inversed: css`
     color: ${sv.white};


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/16778318/72155919-806d5480-33b4-11ea-8e0a-3e7e662a4566.png)
After
![image](https://user-images.githubusercontent.com/16778318/72155938-89f6bc80-33b4-11ea-8e09-8d9c86780ec6.png)
