### PR TITLE
use pointer based events when tooltip child is disabled

### DIFF
--- a/packages/react-drylus/src/components/Tooltip.jsx
+++ b/packages/react-drylus/src/components/Tooltip.jsx
@@ -126,15 +126,22 @@ const Tooltip = ({ responsive, ...rest }) => {
     };
 
     if (childrenRef.current != null) {
-      childrenRef.current.addEventListener('mouseenter', handleMouseEnter);
-      childrenRef.current.addEventListener('mouseleave', handleMouseLeave);
+      if (childrenRef.current.disabled) {
+        childrenRef.current.addEventListener('pointerenter', handleMouseEnter);
+        childrenRef.current.addEventListener('pointerleave', handleMouseLeave);
+      } else {
+        childrenRef.current.addEventListener('mouseenter', handleMouseEnter);
+        childrenRef.current.addEventListener('mouseleave', handleMouseLeave);
+      }
 
       window.addEventListener('scroll', handleMouseLeave, true);
     }
 
     return () => {
       childrenRef.current?.removeEventListener('mouseenter', handleMouseEnter);
+      childrenRef.current?.removeEventListener('pointerenter', handleMouseEnter);
       childrenRef.current?.removeEventListener('mouseleave', handleMouseLeave);
+      childrenRef.current?.removeEventListener('pointerleave', handleMouseLeave);
 
       window.removeEventListener('scroll', handleMouseLeave);
     };

--- a/packages/styleguide/app/pages/component-kit/components/tooltip.mdx
+++ b/packages/styleguide/app/pages/component-kit/components/tooltip.mdx
@@ -11,6 +11,7 @@ import {
   Icon,
   ListTile,
   Text,
+  Color,
 } from '@drawbotics/react-drylus';
 import sv from '@drawbotics/drylus-style-vars';
 
@@ -38,12 +39,12 @@ __Example__
         content={
           <div style={{ textAlign: 'left' }}>
             <Margin size={{ bottom: Size.EXTRA_SMALL }}>
-              <ListTile leading={<Icon name="alert-triangle" category={Category.DANGER} />} title={<Text inversed size={Size.SMALL}>I'm custom content</Text>} />
+              <ListTile leading={<Icon name="alert-triangle" color={Color.RED} />} title={<Text inversed size={Size.SMALL}>I'm custom content</Text>} />
             </Margin>
-            <ListTile leading={<Icon name="check-circle" category={Category.SUCCESS} />} title={<Text inversed size={Size.SMALL}>So am I</Text>} />
+            <ListTile leading={<Icon name="check-circle" color={Color.GREEN} />} title={<Text inversed size={Size.SMALL}>So am I</Text>} />
           </div>
         }>
-        <Dot category={Category.SUCCESS} />
+        <Dot color={Color.GREEN} />
       </Tooltip>
     </FlexItem>
   </Flex>


### PR DESCRIPTION
Fixes issue where the tooltip is not shown if the child element is `disabled` and events are triggered with `mouse` based events. `pointer` based events work when the element is disabled, though this is not supported on safari; not ideal but at least we support both Firefox and Chrome with this, rather than just Firefox.
Link to google chrome issue for reference, maybe one day it'll be shipped. Right now can be enabled through the "experimental web features" flag on chrome: https://www.chromestatus.com/feature/5685077795143680