### PR TITLE
Fix/change Table onClickRow type to generic function callback

### DIFF
--- a/packages/react-drylus/index.d.ts
+++ b/packages/react-drylus/index.d.ts
@@ -929,7 +929,7 @@ export interface TableProps {
   highlighted?: boolean;
   clickable?: boolean;
   isLoading?: boolean;
-  onClickRow?: OnClickCallback;
+  onClickRow?(...args: Array<any>): void;
   activeRow?: any;
   emptyContent?: React.ReactNode;
   style?: object;

--- a/packages/react-drylus/scripts/__tests__/snapshot.d.ts
+++ b/packages/react-drylus/scripts/__tests__/snapshot.d.ts
@@ -929,7 +929,7 @@ export interface TableProps {
   highlighted?: boolean;
   clickable?: boolean;
   isLoading?: boolean;
-  onClickRow?: OnClickCallback;
+  onClickRow?(...args: Array<any>): void;
   activeRow?: any;
   emptyContent?: React.ReactNode;
   style?: object;

--- a/packages/react-drylus/scripts/generate-types.js
+++ b/packages/react-drylus/scripts/generate-types.js
@@ -14,7 +14,7 @@ const folders = [
 function generateTypes(targetFile) {
   const skippedComponents = ['Filter', 'Padding', 'Margin', 'Icon'];
 
-  const onClickExceptions = ['onClickHeader'];
+  const onClickExceptions = ['onClickHeader', 'onClickRow'];
 
   let types = [generateCustomDefinitions()];
 


### PR DESCRIPTION
- Was currently using the `OnClickCallback` type which returned an event, it is now fixed to a generic function type