### PR TITLE
DateInput autoclose

### DIFF
--- a/packages/react-drylus/src/forms/DateInput.tsx
+++ b/packages/react-drylus/src/forms/DateInput.tsx
@@ -371,7 +371,7 @@ export const DateInput = <T extends string>({ responsive, ...rest }: DateInputPr
   const handleOnChange = (v: string) => {
     if (isDesktop) {
       return v;
-    } else if (onChange && Boolean(v)) {
+    } else if (onChange != null && v != null) {
       return onChange(_stringToDateObject(v), name);
     }
   };
@@ -394,7 +394,7 @@ export const DateInput = <T extends string>({ responsive, ...rest }: DateInputPr
         hint={hint}
         loading={loading}
         value={inputValue}
-        onChange={onChange != null ? handleOnChange : null}
+        onChange={handleOnChange}
         ref={inputRef}
         onFocus={onChange != null ? () => setIsFocused(true) : null}
         placeholder={placeholder}
@@ -431,7 +431,12 @@ export const DateInput = <T extends string>({ responsive, ...rest }: DateInputPr
                   locale={locale}
                   activeStartDate={activeStartDate && objectToDate(activeStartDate)}
                   onChange={
-                    onChange != null ? (v) => onChange(dateToObject(v as Date), name) : undefined
+                    onChange != null
+                      ? (v) => {
+                          onChange(dateToObject(v as Date), name);
+                          setTimeout(() => setIsFocused(false), 150);
+                        }
+                      : undefined
                   }
                   value={value === '' ? undefined : objectToDate(value)}
                 />


### PR DESCRIPTION
When picking a date, the input closes automatically after 150ms, similarly to how other pickers work (native and otherwise)

![ezgif-2-de9920a4f269](https://user-images.githubusercontent.com/16778318/94246636-44672900-ff1c-11ea-8914-509e9f0f9008.gif)
