### PR TITLE
Improve multi select with allowtyping

### DIFF
--- a/packages/react-drylus/src/forms/MultiSelect.tsx
+++ b/packages/react-drylus/src/forms/MultiSelect.tsx
@@ -247,6 +247,12 @@ interface TypeZoneProps {
 const TypeZone = forwardRef<HTMLInputElement, TypeZoneProps>(
   ({ placeholder, onPressEnter, onPressDelete }, ref) => {
     const [value, setValue] = useState('');
+
+    const handleSubmit = () => {
+      onPressEnter({ value: `${value}_${Math.random()}`, label: value });
+      setValue('');
+    };
+
     return (
       <div className={styles.typeZone}>
         <input
@@ -256,12 +262,12 @@ const TypeZone = forwardRef<HTMLInputElement, TypeZoneProps>(
           placeholder={placeholder}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && value !== '') {
-              onPressEnter({ value: `${value}_${Math.random()}`, label: value });
-              setValue('');
+              handleSubmit();
             } else if ((e.key === 'Backspace' || e.key === 'Delete') && value === '') {
               onPressDelete();
             }
           }}
+          onBlur={value !== '' ? handleSubmit : undefined}
           onChange={(e: React.FormEvent<HTMLInputElement>) => setValue(e.currentTarget.value)}
         />
       </div>


### PR DESCRIPTION
- Use a chevron icon instead of + for clarity (it's still a select component after all, users don't care about the difference)
- If `hideOptions` is true, no need to show the chevron on the multiselect
- Submit new item when blurring the input typezone

![image](https://user-images.githubusercontent.com/16778318/97892626-8875f680-1d30-11eb-99a4-bba76487678c.png)
![image](https://user-images.githubusercontent.com/16778318/97892640-90359b00-1d30-11eb-9e15-790e39afea39.png)
