### PR TITLE
Add padding size prop to table

### DIFF
--- a/packages/react-drylus/src/components/Table.tsx
+++ b/packages/react-drylus/src/components/Table.tsx
@@ -60,6 +60,15 @@ const styles = {
   fullWidth: css`
     width: 100%;
   `,
+  compact: css`
+    th,
+    td {
+      padding-top: ${sv.paddingExtraSmall};
+      padding-bottom: ${sv.paddingExtraSmall};
+      padding-left: ${sv.paddingSmall};
+      padding-right: ${sv.paddingSmall};
+    }
+  `,
   highlighted: css`
     tr {
       &:hover {
@@ -793,7 +802,9 @@ function _generateRowChildren({
       );
     });
   } else {
-    return Object.values(omitBy(rowData, (_, key) => key.startsWith('_'))).map((value, i) => <TCell key={`${i}-${value}`}>{value}</TCell>);
+    return Object.values(omitBy(rowData, (_, key) => key.startsWith('_'))).map((value, i) => (
+      <TCell key={`${i}-${value}`}>{value}</TCell>
+    ));
   }
 }
 
@@ -1025,6 +1036,12 @@ export interface TableProps {
    * @default true
    */
   responsive?: boolean;
+
+  /**
+   * @default Size.DEFAULT
+   * @kind Size
+   */
+  size?: Size.SMALL | Size.DEFAULT;
 }
 
 export const Table = ({
@@ -1052,6 +1069,7 @@ export const Table = ({
   memoDataValues,
   className,
   responsive = true,
+  size = Size.DEFAULT,
 }: TableProps) => {
   const [rowsStates, setRowState] = useState<Record<string | number, boolean>>({});
   const { screenSize, ScreenSizes } = useScreenSize();
@@ -1218,6 +1236,7 @@ export const Table = ({
                 ))) &&
             (screenSize > ScreenSizes.L || !responsive),
           [styles.highlighted]: highlighted === true && !(hasNestedData || withNesting === true),
+          [styles.compact]: size === Size.SMALL,
         },
         className,
       )}>

--- a/packages/styleguide/app/components/Playground/utils/generate-docs.js
+++ b/packages/styleguide/app/components/Playground/utils/generate-docs.js
@@ -133,16 +133,23 @@ function _parseType(type, docs, componentName, comment, enums) {
     const match = enumTag.text.match(/([A-z]+)/g);
     const enumName = match[0];
     const intrinsic = type.types.filter((t) => t.type === 'intrinsic');
-    const enumValues = match.reduce((memo, name) => [
-      ...memo,
-      ...enums.find((e) => e.name === name).values.map((v) => `${name}.${v}`),
-    ], []);
+    const nonIntrinsic = type.types.filter((t) => t.type !== 'intrinsic');
+    const enumValues = match.reduce(
+      (memo, name) => [
+        ...memo,
+        ...enums
+          .find((e) => e.name === name)
+          .values.filter((e) => !!nonIntrinsic.find((type) => type.name === e))
+          .map((v) => `${name}.${v}`),
+      ],
+      [],
+    );
 
     return {
       type: 'enum',
       name: match.join(','),
       values: [...enumValues, ...intrinsic.map((i) => `${enumName}.${i.name}`)],
-    }
+    };
   } else if (type.type === 'instrinsic') {
     return {
       type: type.name,
@@ -259,7 +266,7 @@ function _getSearchableEnums(docs) {
       name: _enum.name,
       values: _enum.children.map((value) => value.name),
     }));
-    return [ ...memo, ...definitions ];
+    return [...memo, ...definitions];
   }, []);
 }
 


### PR DESCRIPTION
This PR adds the ability to set the table size in between elements, in order to have more compact tables that work on small desktop screens [Example](https://www.figma.com/file/1kVXgpCtmT77tgOWLjshei/CRM---Leads?node-id=3488%3A43556).

The PR also fixes the enum type inference: if you use just a few values from an enum, only those values will appear in the Playground selector

## Previews

### Default Size (what we already have)
![image](https://user-images.githubusercontent.com/13721983/149156279-057a5d95-554c-4573-bae7-cb29cbe6a26d.png)

### Size.Small
![image](https://user-images.githubusercontent.com/13721983/149156162-9eda8816-0cc4-4af9-a351-980269ce38fd.png)
